### PR TITLE
Delegate :empty? to proxy

### DIFF
--- a/lib/simple_enum/multiple/collection_proxy.rb
+++ b/lib/simple_enum/multiple/collection_proxy.rb
@@ -25,7 +25,7 @@ module SimpleEnum
       end
 
       alias_method :to_a, :proxy
-      delegate :inspect, :to_s, :==, :each, :join, to: :proxy
+      delegate :inspect, :to_s, :==, :each, :join, :empty?, to: :proxy
 
     end
   end

--- a/spec/simple_enum/multiple/collection_proxy_spec.rb
+++ b/spec/simple_enum/multiple/collection_proxy_spec.rb
@@ -7,10 +7,17 @@ describe SimpleEnum::Multiple::CollectionProxy do
 
   subject { described_class.new(favorite_cds, accessor) }
 
+  it 'is considered as empty by default' do
+    expect(subject).to be_empty
+    expect(subject).to be_blank
+    expect(subject).to_not be_present
+  end
+
   context '#push' do
     it 'pushes 0, 1 to collection' do
       expect(subject.push(0, 1)).to eq [:iphone, :ipad]
       expect(favorite_cds).to eq [0, 1]
+      expect(subject).to_not be_empty
     end
 
     it 'pushes :iphone, :macbook to collection' do


### PR DESCRIPTION
Without this fix, it was impossible to do something like: `favorites.empty?` or `favorites.blank?`
